### PR TITLE
[DEV-258] Don't catch TypeErrors in handlers

### DIFF
--- a/txjason/client.py
+++ b/txjason/client.py
@@ -80,11 +80,9 @@ class JSONRPCClient(object):
         else:
             params = args
 
-        payload = {
-                    'jsonrpc': '2.0',
-                    'method': __method,
-                    'params': params,
-                  }
+        payload = {'jsonrpc': '2.0',
+                   'method': __method,
+                   'params': params}
         if id:
             payload['id'] = id
         return json.dumps(payload)

--- a/txjason/service.py
+++ b/txjason/service.py
@@ -445,8 +445,6 @@ class JSONRPCService(object):
                 result = yield defer.maybeDeferred(method)
         except JSONRPCError:
             raise
-        except TypeError:
-            raise InvalidParamsError()
         except Exception:
             # Exception was raised inside the method.
             log.msg('Exception raised while invoking RPC method "{}".'.format(


### PR DESCRIPTION
I also made a bunch of lint changes. Just I reminder that you need to get Syntactic with Flake8 set up for your Vim. 
